### PR TITLE
Fix missing requests in transcription workflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ pydantic==2.11.3
 tqdm==4.67.1
 httpx==0.28.1
 feedparser==6.0.11
-requests==2.32.3
+requests==2.31.0
 pydub==0.25.1
+


### PR DESCRIPTION
## Summary
- pin `requests` to a valid version
- ensure newline at end of `requirements.txt`

## Testing
- `pytest -q` *(fails: command not found)*