### PR TITLE
Cleanup duplicate imports

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -3,12 +3,10 @@ import time
 import glob
 import json
 import re
-from typing import List, Dict, Optional, Any, Union, Tuple
-from datetime import datetime, timedelta
-from collections import Counter, defaultdict
-import time
-from datetime import datetime, timedelta
 import calendar
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta
+from typing import List, Dict, Optional, Any, Union, Tuple
 
 from fastapi import FastAPI, HTTPException, Query, Depends, Header
 from fastapi.middleware.cors import CORSMiddleware


### PR DESCRIPTION
## Summary
- remove duplicate `time` and `datetime` imports
- group imports logically at the top of `app.py`

## Testing
- `python -m py_compile api/app.py`